### PR TITLE
Update Dockerfile to configure java for 10s DNS TTL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM tomcat
 
+ENV IMAGE_JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
+
 EXPOSE ${pass.doi.service.port}
 
 ADD  target/pass-doi-service.war /usr/local/tomcat/webapps/
+RUN  echo "networkaddress.cache.ttl=10" >> ${IMAGE_JAVA_HOME}/lib/security/java.security
 
 CMD ["catalina.sh", "run"]


### PR DESCRIPTION
The Docker Maven Plugin seems to execute in the local environment,
and thus has a different value for JAVA_HOME than experienced in the
container.  As a result, IMAGE_JAVA_HOME is used in the build as a
workaround

I cannot build such images on Windows, so this PR is submitted blindly to see what Travis does

Partially addresses OA-PASS/pass-docker#205