### PR TITLE
Upgrade log4j-to-slf4j and log4j-api to 2.15.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <javax.servlet.version>4.0.1</javax.servlet.version>
         <junit.version>4.12</junit.version>
         <logback-classic.version>1.2.3</logback-classic.version>
+        <log4j.version>2.15.0</log4j.version>
         <mockito.version>2.27.0</mockito.version>
         <okhttp.version>3.14.1</okhttp.version>
         <pass.java.client.version>0.6.0</pass.java.client.version>
@@ -377,6 +378,16 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback-classic.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
I haven't clarified the exposure of SL4J to the log4j RCE vulnerability, but this is a simple fix to insure use of log4j 2.15.0.