### PR TITLE
Fix IT failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM tomcat
+FROM tomcat:8
 
 ENV IMAGE_JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/jre
 
 EXPOSE ${pass.doi.service.port}
 
 ADD  target/pass-doi-service.war /usr/local/tomcat/webapps/
-RUN  echo "networkaddress.cache.ttl=10" >> ${IMAGE_JAVA_HOME}/lib/security/java.security
 
 CMD ["catalina.sh", "run"]

--- a/Dockerfile-ITs
+++ b/Dockerfile-ITs
@@ -1,4 +1,4 @@
-FROM tomcat
+FROM tomcat:8
 
 ENV PASS_FEDORA_USER=${pass.fedora.user} \
 PASS_FEDORA_PASSWORD=${pass.fedora.password} \

--- a/src/main/java/org/dataconservancy/pass/doi/service/PassDoiServiceApplication.java
+++ b/src/main/java/org/dataconservancy/pass/doi/service/PassDoiServiceApplication.java
@@ -22,6 +22,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class PassDoiServiceApplication {
 
+    private PassDoiServiceApplication() {}
+
     public static void main(String[] args) {
         SpringApplication.run(PassDoiServiceApplication.class, args);
     }

--- a/src/main/java/org/dataconservancy/pass/doi/service/PassDoiServlet.java
+++ b/src/main/java/org/dataconservancy/pass/doi/service/PassDoiServlet.java
@@ -81,7 +81,6 @@ public class PassDoiServlet extends HttpServlet {
 
     private Set<String> activeJobs = new HashSet<>();
 
-
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
@@ -107,7 +106,8 @@ public class PassDoiServlet extends HttpServlet {
         String doi = request.getParameter("doi");
 
         //stage 1: verify doi is valid
-        if (verify(doi) == null) {//do not have have a valid xref doi
+        if (verify(doi) == null) {
+            // do not have have a valid xref doi
             try (OutputStream out = response.getOutputStream()) {
                 JsonObject jsonObject = Json.createObjectBuilder()
                                             .add("error", "Supplied DOI is not in valid Crossref format.")
@@ -132,8 +132,9 @@ public class PassDoiServlet extends HttpServlet {
                 return;
             }
 
-        } else {//this DOI is not actively being processed
-            //let's temporarily prohibit new requests for this DOI
+        } else {
+            // this DOI is not actively being processed
+            // let's temporarily prohibit new requests for this DOI
             activeJobs.add(doi);
             Thread t = new Thread(new ExpiringLock(doi, cachePeriod));
             t.start();
@@ -170,12 +171,13 @@ public class PassDoiServlet extends HttpServlet {
                 response.setStatus(responseCode);
                 LOG.info(message);
             }
-        } else {//have a non-empty string to process
+        } else {
+            // have a non-empty string to process
             LOG.debug("Building pass journal");
-            //we probably have something JSONy at this point. Let's build a journal object from it
+            // we probably have something JSONy at this point. Let's build a journal object from it
             Journal journal = buildPassJournal(xrefJsonObject);
             LOG.debug("Comparing journal object with possible PASS version");
-            //and compare it with what we already have in PASS, updating PASS if necessary
+            // and compare it with what we already have in PASS, updating PASS if necessary
 
             Journal updatedJournal = updateJournalInPass(journal);
 
@@ -197,8 +199,9 @@ public class PassDoiServlet extends HttpServlet {
                     response.setStatus(200);
                     LOG.info("Returning result for DOI " + doi);
                 }
-            } else {//journal id is null - this should never happen unless Crosssref journal is insufficient
-                //for example, if a book doi ws supplied which has no issns
+            } else {
+                // journal id is null - this should never happen unless Crosssref journal is insufficient
+                // for example, if a book doi ws supplied which has no issns
 
                 try (OutputStream out = response.getOutputStream()) {
                     String message = "Insufficient information to locate or specify a journal entry.";
@@ -311,8 +314,8 @@ public class PassDoiServlet extends HttpServlet {
         }
 
         if (issnArray != null) {
-            for (int i = 0; i < issnArray.size();
-                 i++) {//if we have issns which were not given as typed, we add them without a type
+            for (int i = 0; i < issnArray.size(); i++) {
+                // if we have issns which were not given as typed, we add them without a type
                 String issn = issnArray.getString(i);
                 if (!processedIssns.contains(issn)) {
                     passJournal.getIssns().add(":" + issn);//do this to conform with type:value format
@@ -344,10 +347,13 @@ public class PassDoiServlet extends HttpServlet {
 
         URI passJournalUri = find(name, issns);
 
-        if (passJournalUri == null) {//we don't have this journal in pass yet
-            if (name != null && !name.isEmpty() && issns.size() > 0) {//we have enough info to make a journal entry
+        if (passJournalUri == null) {
+            // we don't have this journal in pass yet
+            if (name != null && !name.isEmpty() && issns.size() > 0) {
+                // we have enough info to make a journal entry
                 passJournal = passClient.createAndReadResource(journal, Journal.class);
-            } else {//do not have enough to create a new journal
+            } else {
+                // do not have enough to create a new journal
                 LOG.debug("Not enough info for journal " + name);
                 return null;
             }
@@ -426,9 +432,13 @@ public class PassDoiServlet extends HttpServlet {
             }
         }
 
-        if (uriScores.size() > 0) {//we have matches, pick the best one
+        if (uriScores.size() > 0) {
+            // we have matches, pick the best one
             Integer highScore = Collections.max(uriScores.values());
-            int minimumQualifyingScore = 1;//with so little to go on, we may realistically get just one hit
+
+            int minimumQualifyingScore = 1;
+            // with so little to go on, we may realistically get just one hit
+
             List<URI> sortedUris = new ArrayList<>();
 
             for (int i = highScore; i >= minimumQualifyingScore; i--) {
@@ -439,10 +449,14 @@ public class PassDoiServlet extends HttpServlet {
                 }
             }
 
-            if (sortedUris.size() > 0) {// there are matching journals
-                return sortedUris.get(0); //return the best match
+            if (sortedUris.size() > 0) {
+                // there are matching journals
+                // return the best match
+                return sortedUris.get(0);
             }
-        } //nothing matches, create a new journal
+        }
+
+        // nothing matches, create a new journal
         return null;
     }
 
@@ -464,7 +478,6 @@ public class PassDoiServlet extends HttpServlet {
         Matcher matcher = pattern.matcher(suffix);
         return matcher.matches() ? suffix : null;
     }
-
 
     /**
      * A class to manage locking so that an active process for a DOI will finish executing before
@@ -499,7 +512,8 @@ public class PassDoiServlet extends HttpServlet {
 
         private String passTypeString;
 
-        static {// these values represent how types are stored on the issn field for the PASS Journal object
+        static {
+            // these values represent how types are stored on the issn field for the PASS Journal object
             PRINT.passTypeString = "Print";
             ELECTRONIC.passTypeString = "Online";
         }
@@ -510,7 +524,8 @@ public class PassDoiServlet extends HttpServlet {
 
         private String crossrefTypeString;
 
-        static {// these values represent how issn types are presented in Crossref metadata
+        static {
+            // these values represent how issn types are presented in Crossref metadata
             PRINT.crossrefTypeString = "print";
             ELECTRONIC.crossrefTypeString = "electronic";
         }

--- a/src/test/java/org/dataconservancy/pass/doi/service/PassDoiServiceIT.java
+++ b/src/test/java/org/dataconservancy/pass/doi/service/PassDoiServiceIT.java
@@ -145,7 +145,8 @@ public class PassDoiServiceIT {
      * @throws Exception if something goes wrong
      */
     @Test
-    public void bookDoiFailTest() throws Exception {//books have isbn, not issn - this should cause a failure
+    public void bookDoiFailTest() throws Exception {
+        // books have isbn, not issn - this should cause a failure
         String bookDoiChapter = "10.1002/0470841559.ch1";
         HttpUrl.Builder urlBuilder = HttpUrl.parse(doiServiceUrl).newBuilder().addQueryParameter("doi", bookDoiChapter);
         String url = urlBuilder.build().toString();

--- a/src/test/java/org/dataconservancy/pass/doi/service/PassDoiServiceTest.java
+++ b/src/test/java/org/dataconservancy/pass/doi/service/PassDoiServiceTest.java
@@ -207,7 +207,6 @@ public class PassDoiServiceTest {
         List<String> issnListOneIssn = new ArrayList<>();
         issnListOneIssn.add(issn5);
 
-
         completeJournal = new Journal();
         completeJournal.setId(completeId);
         completeJournal.setJournalName(journalName);
@@ -226,7 +225,6 @@ public class PassDoiServiceTest {
         missingOneIssnJournal.setJournalName(journalName);
         missingOneIssnJournal.setIssns(issnListOneIssn);
 
-
         when(passClientMock.createAndReadResource(any(), eq(Journal.class))).thenAnswer(i -> {
             final Journal givenJournalToCreate = i.getArgument(0);
             givenJournalToCreate.setId(newJournalId);
@@ -241,7 +239,6 @@ public class PassDoiServiceTest {
             new HashSet<>(Collections.singleton(missingNameId)));
         when(passClientMock.findAllByAttribute(Journal.class, "issns", issn5)).thenReturn(
             new HashSet<>(Collections.singleton(missingOneIssnId)));
-
 
         when(passClientMock.readResource(completeId, Journal.class)).thenReturn(completeJournal);
         when(passClientMock.readResource(missingNameId, Journal.class)).thenReturn(missingNameJournal);
@@ -343,7 +340,6 @@ public class PassDoiServiceTest {
         assertEquals(2, newJournal.getIssns().size());
         assertEquals(nlmta, newJournal.getNlmta());
 
-
         //test that an xref journal with only one issn will find its match in a pass journal containing two issns
         xrefJournal = new Journal();
         xrefJournal.getIssns().add(issn4);
@@ -352,7 +348,6 @@ public class PassDoiServiceTest {
         newJournal = underTest.updateJournalInPass(xrefJournal);
         assertEquals(2, newJournal.getIssns().size());
         assertEquals(nlmta, newJournal.getNlmta());
-
     }
 
     /**
@@ -381,8 +376,6 @@ public class PassDoiServiceTest {
 
         resultUri = underTest.find("MOO", Arrays.asList(issn1, issn2));
         assertNotNull(resultUri);
-
-
     }
 
     /**
@@ -400,7 +393,6 @@ public class PassDoiServiceTest {
         assertNotNull(blob.getJsonObject("message").getJsonArray("ISSN"));
         assertEquals(blob.getJsonObject("message").getJsonArray("ISSN"),
                      object.getJsonObject("message").getJsonArray("ISSN"));
-
     }
 
     /**


### PR DESCRIPTION
This PR fixes some checkstyle errors and pins some docker image tomcat versions so they won't change drastically between builds. The newer tomcats seem to have trouble running the ITs. 

In addition, the doi service image had a modified dns ttl for Java. I removed that modification because it made the docker build fail. It does not seem to be required, but we may have to figure out how to make the change if it is needed in production.